### PR TITLE
SonarCloud js thirdpart/vendor exclusions

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,3 +2,5 @@ sonar.organization=psa
 sonar.projectKey=org.psa:titan-project
 sonar.projectName=Titan project
 sonar.sources=.
+# Exclude all .js (and .map) except 'frontend/js/custom'
+sonar.exclusions=frontend/js/*,frontend/js/ace-min-noconflict/**


### PR DESCRIPTION
Perhaps we can run analysis on a internal SonarQube (from local), avoiding many try.